### PR TITLE
change node version to 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "Hero Journey Club <devs@herojourney.club>"
   ],
   "engines": {
-    "node": "^16"
+    "node": "^18"
   },
   "license": "MPL-2.0",
   "bugs": {


### PR DESCRIPTION
Why does this change, when you are using nextJs or node 18 locally 

This package is not compatible 
![image](https://github.com/HeroJourneyClub/hasura-allow-list-manager/assets/43033153/ba0af6ce-a79e-4d62-90c6-2b963bdfa280)

- But this change builds succeed
- I also create/update the allowlist Hasural queries and it worked as well 
![image](https://github.com/HeroJourneyClub/hasura-allow-list-manager/assets/43033153/877ced22-0cd9-4e46-b53b-fb773387f88d)

